### PR TITLE
made bp_img generation agnostic to 2D/3D

### DIFF
--- a/src/napari_toska/_backend_toska_functions.py
+++ b/src/napari_toska/_backend_toska_functions.py
@@ -708,9 +708,8 @@ def _generate_adjacency_matrix(e_pts, bp_img, branches, structure):
     e_pts = np.asarray(e_pts)
     n_ep = e_pts.shape[0]
     for i in range(n_ep):
-        bp_img[e_pts[i][0],
-               e_pts[i][1]] = n_bp + 1 + i
-
+        bp_img[tuple(e_pts[i])] = n_bp + 1 + i
+        
     adjancency_matrix = np.zeros((n_bp + n_ep, m_branches), dtype = int)
     for i in range(n_bp + n_ep):
         


### PR DESCRIPTION
Hi @allysonryan ,

I found a bug in the adjacency matrix generation. Essentially, in this line where we create the branch point image:

```Python
for i in range(n_ep):
    bp_img[end_points[1], end_points[2]] = n_bp + 1 + i
```

...but we don't check whether bp_img is 2D or 3D. In the 3D case, this messes up the branch points. Anyway, this fixes it :) Feel free to merge if you approve