### PR TITLE
Fix edge case

### DIFF
--- a/src/napari_toska/ToskaSkeleton.py
+++ b/src/napari_toska/ToskaSkeleton.py
@@ -154,7 +154,7 @@ class ToskaSkeleton(Labels):
             connecting_labels = self._find_neighboring_labels(row['label'])
 
             # a branch should connect to exactly two other objects
-            if len(connecting_labels) == 0:
+            if len(connecting_labels) != 2:
                 self.features.iloc[i, self.features.columns.get_loc('object_type')] = 1
                 print('detected malformatted label: {}'.format(int(row['label'])),
                       'changed type from 2 (branch) -> 1 (end point)')
@@ -208,6 +208,13 @@ class ToskaSkeleton(Labels):
         # get bounding box around branch
         min_coords = branch_point_coordinates.min(axis=0) - 1
         max_coords = branch_point_coordinates.max(axis=0) + 2
+
+        # check if min/max values exceed array dimensions
+        min_coords[min_coords < 0] = 0
+        for i in range(len(max_coords)):
+            if max_coords[i] > branch.shape[i]:
+                max_coords[i] = branch.shape[i] 
+
         # Create a tuple of slices for each dimension
         slices = tuple(
             slice(min_coord, max_coord) for min_coord, max_coord in zip(min_coords, max_coords)

--- a/src/napari_toska/_tests/test_skeletons.py
+++ b/src/napari_toska/_tests/test_skeletons.py
@@ -16,6 +16,33 @@ def test_skeletonization():
     assert labeled_skeleton.max() == 15
 
 
+def test_edge_case():
+    """
+    This test checks whether the Toska Analysis works
+    if parts of the skeleton are located at the edge of the image.
+    """
+    import numpy as np
+    import napari_toska as nts
+
+    labels = np.array([
+        [0, 0, 0, 0, 0, 0, 0, 0, 0,],
+        [0, 1, 0, 0, 0, 0, 0, 0, 0,],
+        [0, 0, 1, 0, 0, 0, 1, 0, 0,],
+        [0, 0, 0, 1, 0, 1, 0, 0, 2,],
+        [0, 0, 0, 0, 1, 0, 0, 0, 2,],
+        [0, 0, 0, 0, 1, 0, 2, 2, 2,],
+        [0, 0, 0, 0, 1, 0, 0, 2, 2,],
+        [0, 0, 0, 0, 1, 0, 0, 0, 2,],
+        [0, 0, 0, 1, 0, 1, 0, 0, 2,],
+        [0, 0, 1, 0, 0, 0, 1, 0, 0,],
+        [0, 0, 0, 0, 0, 0, 0, 1, 0,],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0,],
+    ])
+
+    Skeleton = nts.ToskaSkeleton(labels, neighborhood='n8')
+    Skeleton.analyze()
+
+
 def test_simple_skeleton():
     import napari_toska as nts
     from skimage.morphology import skeletonize

--- a/src/napari_toska/_tests/test_skeletons.py
+++ b/src/napari_toska/_tests/test_skeletons.py
@@ -37,7 +37,7 @@ def test_edge_case():
         [0, 0, 1, 0, 0, 0, 1, 0, 0,],
         [0, 0, 0, 0, 0, 0, 0, 1, 0,],
         [0, 0, 0, 0, 0, 0, 0, 0, 0,],
-    ])
+    ], dtype=np.uint8)
 
     Skeleton = nts.ToskaSkeleton(labels, neighborhood='n8')
     Skeleton.analyze()


### PR DESCRIPTION
This pull request includes several changes to the `ToskaSkeleton` class and its associated tests to improve robustness and accuracy. The most important changes include a fix to the label connection logic, a check to prevent out-of-bounds errors, and the addition of a new test case for edge conditions.

### Improvements to label connection logic:
* Modified the condition in `_build_nx_graph` to correctly identify branches by ensuring they connect to exactly two other objects. (`src/napari_toska/ToskaSkeleton.py`)

### Robustness enhancements:
* Added a check in `_find_neighboring_labels` to ensure that the minimum and maximum coordinates do not exceed the array dimensions, preventing potential out-of-bounds errors. (`src/napari_toska/ToskaSkeleton.py`)

### Testing improvements:
* Introduced a new test case `test_edge_case` to verify the functionality of the Toska Analysis when parts of the skeleton are at the edge of the image. (`src/napari_toska/_tests/test_skeletons.py`)