### PR TITLE
expand test cases and drop python 3.8

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     napari_workflows
     napari_skimage_regionprops
 
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 package_dir =
     =src

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{39,310,311,312}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
This pull request includes updates to the CI configuration and package requirements to support newer Python versions.

CI configuration updates:

* [`.github/workflows/test_and_deploy.yaml`](diffhunk://#diff-11a5467191c05be6a1f5f2bd0182bc72c2bb0bd768417cb0e91da1a52ae6c647L23-R23): Updated the `python-version` matrix to include Python 3.11 and 3.12, while removing support for Python 3.8.

Package requirements updates:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L45-R45): Changed `python_requires` to require Python 3.9 or higher.