### PR TITLE
set categorical columns

### DIFF
--- a/src/napari_toska/ToskaSkeleton.py
+++ b/src/napari_toska/ToskaSkeleton.py
@@ -128,12 +128,14 @@ class ToskaSkeleton(Labels):
             'object_type': object_types,
         })
 
-        # add skeleton ID to features
+        # add skeleton ID to features as a categorical column
         for i, row in self.features.iterrows():
             self.features.loc[i, 'skeleton_id'] = labelled_skeletons[self.data == row['label']][0]
 
-        # make column type int
-        self.features['skeleton_id'] = self.features['skeleton_id'].astype(int)
+        # make column type categorical
+        self.features['skeleton_id'] = self.features['skeleton_id'].astype('category')
+        self.features['object_type'] = self.features['object_type'].astype('category')
+        self.features['label'] = self.features['label'].astype('category')
 
         return
     
@@ -295,6 +297,9 @@ class ToskaSkeleton(Labels):
             
             for label in longest_shortest_path['edge_labels']:
                 self.features.loc[self.features['label'] == label, 'spine'] = 1
+
+        # make spine column categorical
+        self.features['spine'] = self.features['spine'].astype('category')
                 
     def _graph_summary(self):
         """


### PR DESCRIPTION
@allysonryan here comes another (but *super*cool) PR! Essentially, a bunch of columns in the skeleton feature table are formatted as `categorical` (i.e, `skeleton_id`), which makes the plugin usable in a super-smooth way with the new and upcoming napari-clusters-plotter:

https://github.com/user-attachments/assets/4e07958e-cfbb-4f53-8028-0065672e4fc5

